### PR TITLE
CLD-318 - Merge patches from vert.x 2.1.2-KG8 into 2.1.7-KG1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,16 @@ buildscript {
       // are concurrent builds
       mavenLocal()
     }
+    if (System.getenv("VERTX_ADDITIONAL_MAVEN_REPO") != null) {
+      maven {
+        name "additionalVertxRepo"
+        url System.getenv("VERTX_ADDITIONAL_MAVEN_REPO")
+        credentials {
+          username System.getenv("VERTX_ADDITIONAL_MAVEN_REPO_USER")
+          password System.getenv("VERTX_ADDITIONAL_MAVEN_REPO_PASSWORD")
+        }
+      }
+    }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     mavenCentral()
   }
@@ -58,6 +68,16 @@ subprojects {
   repositories {
     if (System.getenv("VERTX_DISABLE_MAVENLOCAL") == null) {
       mavenLocal()
+    }
+    if (System.getenv("VERTX_ADDITIONAL_MAVEN_REPO") != null) {
+      maven {
+        name "additionalVertxRepo"
+        url System.getenv("VERTX_ADDITIONAL_MAVEN_REPO")
+        credentials {
+          username System.getenv("VERTX_ADDITIONAL_MAVEN_REPO_USER")
+          password System.getenv("VERTX_ADDITIONAL_MAVEN_REPO_PASSWORD")
+        }
+      }
     }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     mavenCentral()
@@ -135,7 +155,7 @@ task assemble(type: Copy, dependsOn: [subprojects.assemble]) {
     from subprojects.configurations.compile    
     from subprojects.jar
     // Don't just include everything!!
-    includes = ["jackson*.jar", "netty*.jar", "hazelcast*.jar", "vertx*.jar"]
+    includes = ["jackson*.jar", "netty*.jar", "hazelcast*.jar", "vertx*.jar", "*slf4j*.jar"]
   }
   doLast {
     project.ant.chmod(file: "build/$rootProject.name-$version/bin", perm: 'ugo+x')

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,18 +18,18 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.7-SNAPSHOT
+version=2.1.7-KG1
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x
 group=io.vertx
 
 # dependency versions
-hazelcastVersion=3.5
+hazelcastVersion=3.5.5
 jacksonCoreVersion=2.2.2
 jacksonDatabindVersion=2.2.2
 nettyVersion=4.0.21.Final
 log4jVersion=1.2.16
-slf4jVersion=1.6.2
+slf4jVersion=1.7.13
 junitVersion=4.10
 toolsVersion=2.0.3-final

--- a/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBus.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/eventbus/impl/DefaultEventBus.java
@@ -16,6 +16,18 @@
 
 package org.vertx.java.core.eventbus.impl;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.MDC;
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.AsyncResultHandler;
 import org.vertx.java.core.Handler;
@@ -43,22 +55,18 @@ import org.vertx.java.core.spi.cluster.AsyncMultiMap;
 import org.vertx.java.core.spi.cluster.ChoosableIterable;
 import org.vertx.java.core.spi.cluster.ClusterManager;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
 /**
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class DefaultEventBus implements EventBus {
+
+  public enum LoadBalanceMode {
+    RoundRobin,
+    PreferLocal
+  }
+
+  public static final String VERTX_CLUSTER_LOADBALANCE = "vertx.cluster.loadbalancing";
 
   private static final Logger log = LoggerFactory.getLogger(DefaultEventBus.class);
 
@@ -74,6 +82,7 @@ public class DefaultEventBus implements EventBus {
   private final ConcurrentMap<String, Handlers> handlerMap = new ConcurrentHashMap<>();
   private final ClusterManager clusterMgr;
   private final AtomicLong replySequence = new AtomicLong(0);
+  private LoadBalanceMode loadBalanceMode = LoadBalanceMode.RoundRobin;
 
   public DefaultEventBus(VertxInternal vertx) {
     // Just some dummy server ID
@@ -95,7 +104,16 @@ public class DefaultEventBus implements EventBus {
     this.clusterMgr = clusterManager;
     this.subs = clusterMgr.getAsyncMultiMap("subs");
     this.server = setServer(port, hostname, listenHandler);
-    ManagementRegistry.registerEventBus(serverID);
+    setLoadBalanceMode();
+  }
+
+  private void setLoadBalanceMode() {
+    try {
+      this.loadBalanceMode = LoadBalanceMode.valueOf(System.getProperty(VERTX_CLUSTER_LOADBALANCE, LoadBalanceMode.RoundRobin.name()));
+      log.info("cluster loadbalancing mode: " + this.loadBalanceMode);
+    } catch (IllegalArgumentException e) {
+      log.error("invalid load balance mode: " + System.getProperty(VERTX_CLUSTER_LOADBALANCE, LoadBalanceMode.RoundRobin.name()));
+    }
   }
 
   @Override
@@ -625,6 +643,7 @@ public class DefaultEventBus implements EventBus {
           int serverPort = (publicPort == -1) ? server.port() : publicPort;
           String serverHost = (publicHost == null) ? hostName : publicHost;
           DefaultEventBus.this.serverID = new ServerID(serverPort, serverHost);
+          ManagementRegistry.registerEventBus(serverID);
         }
         if (listenHandler != null) {
           if (asyncResult.succeeded()) {
@@ -733,7 +752,14 @@ public class DefaultEventBus implements EventBus {
               if (event.succeeded()) {
                 ChoosableIterable<ServerID> serverIDs = event.result();
                 if (serverIDs != null && !serverIDs.isEmpty()) {
-                  sendToSubs(serverIDs, message, fTimeoutID, asyncResultHandler, replyHandler);
+                  if (message.send
+                      && loadBalanceMode == LoadBalanceMode.PreferLocal
+                      && serverIDs.contains(serverID)) {
+                    // stay in this node
+                    receiveMessage(message, fTimeoutID, asyncResultHandler, replyHandler);
+                  } else {
+                    sendToSubs(serverIDs, message, fTimeoutID, asyncResultHandler, replyHandler);
+                  }
                 } else {
                   receiveMessage(message, fTimeoutID, asyncResultHandler, replyHandler);
                 }
@@ -960,7 +986,23 @@ public class DefaultEventBus implements EventBus {
         // before it was received
         try {
           if (!holder.removed) {
-            holder.handler.handle(copied);
+            if (!DefaultContext.isMDCAware) {
+              holder.handler.handle(copied);
+              return;
+            }
+            Map<String, String> save = MDC.getCopyOfContextMap();
+            try {
+              MDC.clear();
+              if (holder.mdcValues != null && !holder.mdcValues.isEmpty()) {
+                MDC.setContextMap(holder.mdcValues);
+              }
+              holder.handler.handle(copied);
+            } finally {
+              MDC.clear();
+              if (save != null && !save.isEmpty()) {
+                MDC.setContextMap(save);
+              }
+            }
           }
         } finally {
           if (holder.replyHandler) {
@@ -978,12 +1020,14 @@ public class DefaultEventBus implements EventBus {
   }
 
   private static class HandlerHolder<T> {
+    private static boolean isMDCAware = Boolean.parseBoolean(System.getProperty("vertx.logger.mdcaware", "false"));
     final DefaultContext context;
     final Handler<Message<T>> handler;
     final boolean replyHandler;
     final boolean localOnly;
     final long timeoutID;
     boolean removed;
+    Map<String, String> mdcValues;
 
     HandlerHolder(Handler<Message<T>> handler, boolean replyHandler, boolean localOnly, DefaultContext context, long timeoutID) {
       this.context = context;
@@ -991,6 +1035,9 @@ public class DefaultEventBus implements EventBus {
       this.replyHandler = replyHandler;
       this.localOnly = localOnly;
       this.timeoutID = timeoutID;
+      if (isMDCAware) {
+        mdcValues = MDC.getCopyOfContextMap();
+      }
     }
 
     @Override

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/VertxHttpHandler.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/VertxHttpHandler.java
@@ -15,6 +15,8 @@
  */
 package org.vertx.java.core.http.impl;
 
+import java.util.Map;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufHolder;
@@ -28,15 +30,12 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.websocketx.*;
-import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.vertx.java.core.http.impl.ws.DefaultWebSocketFrame;
 import org.vertx.java.core.http.impl.ws.WebSocketFrameInternal;
 import org.vertx.java.core.impl.DefaultContext;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.net.impl.ConnectionBase;
 import org.vertx.java.core.net.impl.VertxHandler;
-
-import java.util.Map;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
@@ -142,22 +141,22 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
       }
       switch (frame.type()) {
         case BINARY:
-          msg = new BinaryWebSocketFrame(buf);
+          msg = new BinaryWebSocketFrame(frame.isFinalFrame(), 0, buf);
           break;
         case TEXT:
-          msg = new TextWebSocketFrame(buf);
+          msg = new TextWebSocketFrame(frame.isFinalFrame(), 0, buf);
           break;
         case CLOSE:
           msg = new CloseWebSocketFrame(true, 0, buf);
           break;
         case CONTINUATION:
-          msg = new ContinuationWebSocketFrame(buf);
+          msg = new ContinuationWebSocketFrame(frame.isFinalFrame(), 0, buf);
           break;
         case PONG:
-          msg = new PongWebSocketFrame(buf);
+          msg = new PongWebSocketFrame(frame.isFinalFrame(), 0, buf);
           break;
         case PING:
-          msg = new PingWebSocketFrame(buf);
+          msg = new PingWebSocketFrame(frame.isFinalFrame(), 0, buf);
           break;
         default:
           throw new IllegalStateException("Unsupported websocket msg " + msg);

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/WebSocketImplBase.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/WebSocketImplBase.java
@@ -16,7 +16,9 @@
 
 package org.vertx.java.core.http.impl;
 
-import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.buffer.Buffer;
 import org.vertx.java.core.eventbus.Message;
@@ -27,7 +29,11 @@ import org.vertx.java.core.http.impl.ws.WebSocketFrameInternal;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.net.impl.ConnectionBase;
 
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -35,6 +41,14 @@ import java.util.UUID;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public abstract class WebSocketImplBase<T> implements WebSocketBase<T> {
+
+  /**
+   * size of the websocket chunk. This is the default value, maybe should be
+   * made configurable
+   */
+  private static final int DEFAULT_CHUNK_SIZE = 65536;
+
+  private int chunkSize = DEFAULT_CHUNK_SIZE;
 
   private final String textHandlerID;
   private final String binaryHandlerID;
@@ -51,11 +65,14 @@ public abstract class WebSocketImplBase<T> implements WebSocketBase<T> {
   protected Handler<Message<String>> textHandler;
   protected boolean closed;
 
+  private CompositeByteBuf wsFramesCollector;
+
   protected WebSocketImplBase(VertxInternal vertx, ConnectionBase conn) {
     this.vertx = vertx;
     this.textHandlerID = UUID.randomUUID().toString();
     this.binaryHandlerID = UUID.randomUUID().toString();
     this.conn = conn;
+    wsFramesCollector = Unpooled.compositeBuffer();
     binaryHandler = new Handler<Message<Buffer>>() {
       public void handle(Message<Buffer> msg) {
         writeBinaryFrameInternal(msg.body());
@@ -100,16 +117,121 @@ public abstract class WebSocketImplBase<T> implements WebSocketBase<T> {
   }
 
   protected void writeBinaryFrameInternal(Buffer data) {
-    ByteBuf buf = data.getByteBuf();
-    WebSocketFrame frame = new DefaultWebSocketFrame(WebSocketFrame.FrameType.BINARY, buf);
-    writeFrame(frame);
+    if (data != null && data.getBytes() != null && data.getBytes().length != 0) {
+      byte[][] chunks = chunkMessage(data.getBytes());
+      for (int i = 0; i < chunks.length; i++) {
+        boolean finalFrame = i == chunks.length - 1;
+        WebSocketFrame.FrameType frameType = i == 0 ? WebSocketFrame.FrameType.BINARY : WebSocketFrame.FrameType.CONTINUATION;
+        WebSocketFrame frame = new DefaultWebSocketFrame(frameType, Unpooled.copiedBuffer(chunks[i]), finalFrame);
+        writeFrame(frame);
+      }
+    } else {
+      WebSocketFrame frame = new DefaultWebSocketFrame(WebSocketFrame.FrameType.BINARY);
+      writeFrame(frame);
+    }
   }
 
-  protected void writeTextFrameInternal(String str) {
-    WebSocketFrame frame = new DefaultWebSocketFrame(str);
-    writeFrame(frame);
+  protected void writeTextFrameInternal(String data) {
+    if (data != null && !data.isEmpty()) {
+      List<String> chunks = chunkMessage(data);
+      for (int i = 0; i < chunks.size(); i++) {
+        boolean finalFrame = i == chunks.size() - 1;
+        WebSocketFrame frame;
+        if (i == 0) {
+          frame = new DefaultWebSocketFrame(chunks.get(i), finalFrame);
+        } else {
+          try {
+            frame = new DefaultWebSocketFrame(WebSocketFrame.FrameType.CONTINUATION, Unpooled.copiedBuffer(chunks.get(i).getBytes("UTF-8")),
+                finalFrame);
+          } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+          }
+        }
+        writeFrame(frame);
+      }
+    } else {
+      WebSocketFrame frame = new DefaultWebSocketFrame(WebSocketFrame.FrameType.TEXT);
+      writeFrame(frame);
+    }
   }
 
+  /**
+   * @param message
+   *          the message to be chunked. Is assumed to be non-empty string
+   * @return bytes array with the message chunks
+   */
+  byte[][] chunkMessage(byte[] messageBytes) {
+    byte[][] resChunks = new byte[messageBytes.length / chunkSize + (messageBytes.length % chunkSize > 0 ? 1 : 0)][];
+    for (int chunkIndex = 0; chunkIndex < resChunks.length; chunkIndex++) {
+      resChunks[chunkIndex] = Arrays.copyOfRange(messageBytes, chunkIndex * chunkSize, Math.min((chunkIndex + 1) * chunkSize, messageBytes.length));
+    }
+    return resChunks;
+  }
+
+  /**
+   * splits the provided string into chunks of byte lengths not exceding the
+   * CHUNK_SIZE
+   * 
+   * @param str
+   *          the string to be splitted. Is assumed to be a not-null string
+   * 
+   * @return list of chunks
+   */
+  List<String> chunkMessage(String str) {
+    int offset = 0;
+    List<String> chunks = new ArrayList<>();
+    while (offset < str.length()) {
+      String chunk = getUTF8LongestPrefix(str.substring(offset), chunkSize);
+      chunks.add(chunk);
+      offset += chunk.length();
+    }
+    return chunks;
+  }
+
+  /**
+   * 
+   * @param str
+   *          the string. It is assumed to be a non-empty string
+   * @param bytesLengthLimit
+   *          size limit of the prefix. It is assumed to be non-negative integer
+   * @return the longest prefix that does not exceed the bytesLengthLimit when
+   *         encoded with UTF-8 scheme
+   */
+  String getUTF8LongestPrefix(String str, int bytesLengthLimit) {
+    int prefixLengthInBytes = 0;
+    int currentIndex = 0;
+    while (prefixLengthInBytes <= bytesLengthLimit && currentIndex < str.length()) {
+      int cp = str.codePointAt(currentIndex);
+      prefixLengthInBytes += getBytesAmountForUTF8Encoding(cp);
+      if (!Character.isSupplementaryCodePoint(cp))
+        currentIndex++;
+      else
+        currentIndex += 2;
+    }
+    return str.substring(0, currentIndex - (prefixLengthInBytes > bytesLengthLimit ? 1 : 0));
+  }
+
+  /**
+   * @param codePoint
+   *          the codePoint
+   * @return amount of bytes that are needed to encode the specified codePoint
+   *         with UTF-8 scheme (rfc 3629)
+   */
+  private int getBytesAmountForUTF8Encoding(int codePoint) {
+    /*
+     * input data is not checked since it is a private method, and the code
+     * point is guaranteed to be of the valid value
+     */
+    if (codePoint < 0x0080)
+      return 1;
+    else if (codePoint < 0x0800)
+      return 2;
+    else if (codePoint < 0x00010000)
+      return 3;
+    else if (codePoint < 0x00110000)
+      return 4;
+    throw new IllegalArgumentException("The code point must be in the range 0x0000 to 0x0010FFFF");
+  }
 
   private void cleanupHandlers() {
     if (!closed) {
@@ -132,8 +254,22 @@ public abstract class WebSocketImplBase<T> implements WebSocketBase<T> {
 
   void handleFrame(WebSocketFrameInternal frame) {
     if (dataHandler != null) {
-      Buffer buff = new Buffer(frame.getBinaryData());
-      dataHandler.handle(buff);
+      switch (frame.type()) {
+      case PING:
+      case PONG:
+      case CLOSE:
+      case TEXT:
+      case BINARY:
+        wsFramesCollector.clear();
+        wsFramesCollector.removeComponents(0, wsFramesCollector.numComponents());
+      case CONTINUATION:
+        wsFramesCollector.addComponent(frame.getBinaryData());
+      }
+      if (frame.isFinalFrame()) {
+        wsFramesCollector.writerIndex(wsFramesCollector.capacity());
+        Buffer buff = new Buffer(wsFramesCollector);
+        dataHandler.handle(buff);
+      }
     }
 
     if (frameHandler != null) {
@@ -163,5 +299,13 @@ public abstract class WebSocketImplBase<T> implements WebSocketBase<T> {
     if (closeHandler != null) {
       closeHandler.handle(null);
     }
+  }
+
+  public int getChunkSize() {
+    return chunkSize;
+  }
+
+  public void setChunkSize(int chunkSize) {
+    this.chunkSize = chunkSize;
   }
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/impl/DefaultContext.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/DefaultContext.java
@@ -16,8 +16,14 @@
 
 package org.vertx.java.core.impl;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import org.slf4j.MDC;
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.AsyncResultHandler;
 import org.vertx.java.core.Context;
@@ -26,15 +32,11 @@ import org.vertx.java.core.file.impl.PathResolver;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.Executor;
-
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public abstract class DefaultContext implements Context {
-
+  public static boolean isMDCAware = Boolean.parseBoolean(System.getProperty("vertx.logger.mdcaware", "false"));
   private static final Logger log = LoggerFactory.getLogger(DefaultContext.class);
 
   protected final VertxInternal vertx;
@@ -130,17 +132,22 @@ public abstract class DefaultContext implements Context {
 
   public abstract boolean isOnCorrectWorker(EventLoop worker);
 
-  public void execute(EventLoop worker, Runnable handler) {
+  public void execute(EventLoop worker, final Runnable handler) {
     if (isOnCorrectWorker(worker)) {
       wrapTask(handler).run();
     } else {
-      execute(handler);
+      execute(new MDCAwareRunnable() {
+        @Override
+        void invoke() {
+          handler.run();
+        }
+      });
     }
   }
 
   public void runOnContext(final Handler<Void> task) {
-    execute(new Runnable() {
-      public void run() {
+    execute(new MDCAwareRunnable() {
+      public void invoke() {
         task.handle(null);
       }
     });
@@ -166,8 +173,8 @@ public abstract class DefaultContext implements Context {
   }
 
   protected Runnable wrapTask(final Runnable task) {
-    return new Runnable() {
-      public void run() {
+    return new MDCAwareRunnable() {
+      public void invoke() {
         Thread currentThread = Thread.currentThread();
         String threadName = currentThread.getName();
         try {
@@ -187,6 +194,38 @@ public abstract class DefaultContext implements Context {
         }
       }
     };
+  }
+
+  private static abstract class MDCAwareRunnable implements Runnable {
+    private Map<String, String> values;
+
+    public MDCAwareRunnable() {
+      if (isMDCAware) {
+        values = MDC.getCopyOfContextMap();
+      }
+    }
+
+    public void run() {
+      if (!isMDCAware) {
+        invoke();
+        return;
+      }
+      Map<String, String> save = MDC.getCopyOfContextMap();
+      try {
+        MDC.clear();
+        if (values != null && !values.isEmpty()) {
+          MDC.setContextMap(values);
+        }
+        invoke();
+      } finally {
+        MDC.clear();
+        if (save != null && !save.isEmpty()) {
+          MDC.setContextMap(save);
+        }
+      }
+    }
+
+    abstract void invoke();
   }
 
 }

--- a/vertx-core/src/main/java/org/vertx/java/core/logging/impl/LoggerFactory.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/logging/impl/LoggerFactory.java
@@ -16,10 +16,10 @@
 
 package org.vertx.java.core.logging.impl;
 
-import org.vertx.java.core.logging.Logger;
-
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import org.vertx.java.core.logging.Logger;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -43,7 +43,7 @@ public class LoggerFactory {
     // programmatically - this is primarily of use so we can configure the logger delegate on the client side.
     // call to System.getProperty is wrapped in a try block as it will fail if the client runs in a secured
     // environment
-    String className = JULLogDelegateFactory.class.getName();
+    String className = SLF4JLogDelegateFactory.class.getName();
     try {
       className = System.getProperty(LOGGER_DELEGATE_FACTORY_CLASS_NAME);
     } catch (Exception e) {
@@ -58,7 +58,7 @@ public class LoggerFactory {
         throw new IllegalArgumentException("Error instantiating transformer class \"" + className + "\"", e);
       }
     } else {
-      delegateFactory = new JULLogDelegateFactory();
+      delegateFactory = new SLF4JLogDelegateFactory();
     }
 
     LoggerFactory.delegateFactory = delegateFactory;

--- a/vertx-core/src/main/java/org/vertx/java/core/spi/cluster/ChoosableIterable.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/spi/cluster/ChoosableIterable.java
@@ -36,4 +36,13 @@ public interface ChoosableIterable<T> extends Iterable<T>{
    * @return The next element
    */
   T choose();
+  
+  
+  /**
+   * Check if in item is present in the iterator
+   * 
+   * @param item
+   * @return true if the item is present
+   */
+  boolean contains(T item);
 }

--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/ChoosableSet.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/ChoosableSet.java
@@ -16,12 +16,12 @@
 
 package org.vertx.java.spi.cluster.impl.hazelcast;
 
-import org.vertx.java.core.impl.ConcurrentHashSet;
-import org.vertx.java.core.spi.cluster.ChoosableIterable;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import org.vertx.java.core.impl.ConcurrentHashSet;
+import org.vertx.java.core.spi.cluster.ChoosableIterable;
 
 /**
  *
@@ -83,5 +83,10 @@ class ChoosableSet<T> implements ChoosableIterable<T> {
     } else {
       return null;
     }
+  }
+
+  @Override
+  public boolean contains(T item) {
+    return ids.contains(item);
   }
 }

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/ModuleClassLoader.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/ModuleClassLoader.java
@@ -16,15 +16,15 @@
 
 package org.vertx.java.platform.impl;
 
-import org.vertx.java.core.impl.ConcurrentHashSet;
-import org.vertx.java.core.logging.Logger;
-import org.vertx.java.core.logging.impl.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
+
+import org.vertx.java.core.impl.ConcurrentHashSet;
+import org.vertx.java.core.logging.Logger;
+import org.vertx.java.core.logging.impl.LoggerFactory;
 
 /**
  * Each module (not module instance) is assigned it's own ModuleClassLoader.
@@ -56,7 +56,7 @@ public class ModuleClassLoader extends URLClassLoader {
   private final Set<ModuleReference> references = new ConcurrentHashSet<>();
   private final ClassLoader platformClassLoader;
   private final boolean loadFromModuleFirst;
-  private Set<ModuleClassLoader> modGraph;
+  private volatile Set<ModuleClassLoader> modGraph;
 
   public ModuleClassLoader(String modID, ClassLoader platformClassLoader, URL[] classpath,
                            boolean loadFromModuleFirst) {
@@ -158,9 +158,15 @@ public class ModuleClassLoader extends URLClassLoader {
 
   private Set<ModuleClassLoader> getModuleGraph() {
     if (modGraph == null) {
-      modGraph = new ConcurrentHashSet<ModuleClassLoader>();
-      modGraph.add(this);
-      computeModules(modGraph);
+      synchronized (this) {
+        if (modGraph != null) {
+          return modGraph;
+        }
+        Set<ModuleClassLoader> graph = new LinkedHashSet<>();
+        graph.add(this);
+        computeModules(graph);
+        modGraph = graph;
+      }
     }
     return modGraph;
   }
@@ -234,80 +240,4 @@ public class ModuleClassLoader extends URLClassLoader {
       }
     }
   }
-
-  private static final class LinkedHashSet<T> implements Set<T> {
-
-    private final Object obj = new Object();
-
-    private final Map<T, Object> map = new LinkedHashMap<>();
-
-    @Override
-    public int size() {
-      return map.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-      return map.isEmpty();
-    }
-
-    @Override
-    public boolean contains(Object o) {
-      return map.containsKey(o);
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-      return map.keySet().iterator();
-    }
-
-    @Override
-    public Object[] toArray() {
-      return map.keySet().toArray();
-    }
-
-    @Override
-    public <T1> T1[] toArray(T1[] a) {
-      return map.keySet().toArray(a);
-    }
-
-    @Override
-    public boolean add(T t) {
-      map.put(t, obj);
-      return true;
-    }
-
-    @Override
-    public boolean remove(Object o) {
-      return map.remove(o) != null;
-    }
-
-    @Override
-    public boolean containsAll(Collection<?> c) {
-      return map.keySet().containsAll(c);
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends T> c) {
-      return false;
-    }
-
-    @Override
-    public boolean retainAll(Collection<?> c) {
-      return false;
-    }
-
-    @Override
-    public boolean removeAll(Collection<?> c) {
-      return false;
-    }
-
-    @Override
-    public void clear() {
-      map.clear();
-    }
-
-  }
-
-
 }

--- a/vertx-testsuite/src/test/java/org/vertx/java/fakecluster/ChoosableSet.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/fakecluster/ChoosableSet.java
@@ -16,12 +16,12 @@
 
 package org.vertx.java.fakecluster;
 
-import org.vertx.java.core.impl.ConcurrentHashSet;
-import org.vertx.java.core.spi.cluster.ChoosableIterable;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import org.vertx.java.core.impl.ConcurrentHashSet;
+import org.vertx.java.core.spi.cluster.ChoosableIterable;
 
 /**
  *
@@ -74,5 +74,10 @@ class ChoosableSet<T> implements ChoosableIterable<T> {
     } else {
       return null;
     }
+  }
+  
+  @Override
+  public boolean contains(T item) {
+	  return ids.contains(item);
   }
 }


### PR DESCRIPTION
- Upmerged patches for Vert.x 2.1.2-KG8 into Vert.x 2.1.7
  - readded patch for support of additional Maven repos in build.gradle
  - readded patch for MDC awareness in DefaultEventBus
  - readded patch for "load balanced mode" where messages are sent to the local node if possible
  - readded patch for chunked WebSocket frames
  - readded patch for logging default to SLF4J
  - readded patch for synchronized and so hopefully race-free module graph creation
- set project version to 2.1.7-KG1
- raised Hazelcast dependency to 3.5.5
- raised SLF4J dependency to 1.7.13
