### PR TITLE
V2.1.7 kiwigrid

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.7-KG1
+version=2.1.7-KG2
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x

--- a/vertx-core/src/main/java/org/vertx/java/core/impl/DefaultVertx.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/DefaultVertx.java
@@ -354,6 +354,8 @@ public class DefaultVertx implements VertxInternal {
       sharedNetServers.clear();
     }
 
+    eventBus.close(null);
+
     if (backgroundPool != null) {
       backgroundPool.shutdown();
     }
@@ -370,8 +372,6 @@ public class DefaultVertx implements VertxInternal {
     if (eventLoopGroup != null) {
       eventLoopGroup.shutdownGracefully();
     }
-
-    eventBus.close(null);
 
     setContext(null);
   }

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
@@ -376,10 +376,16 @@ public class TCPSSLHelper {
   }
 
   // Make sure SSLv3 is NOT enabled due to POODLE issue http://en.wikipedia.org/wiki/POODLE
-  private static final String[] ENABLED_PROTOCOLS = {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+  private static final String[] ENABLED_SERVER_PROTOCOLS = {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+  // clients shall not use SSLv2Hello since this is used autimatically and gonna break SNI
+  private static final String[] ENABLED_CLIENT_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2"};
 
   private SslHandler createHandler(SSLEngine engine, boolean client) {
-    engine.setEnabledProtocols(ENABLED_PROTOCOLS);
+    if (client) {
+      engine.setEnabledProtocols(ENABLED_CLIENT_PROTOCOLS);
+    } else {
+      engine.setEnabledProtocols(ENABLED_SERVER_PROTOCOLS);
+    }
     engine.setUseClientMode(client);
     if (!client) {
       switch (getClientAuth()) {


### PR DESCRIPTION
See commit comments for details. Should fix:
- http client does not support SNI since SSLv2Hello ist used for Hello Packet
- graceful shutdown failed to cleanup some handlers since the background pool was shut down already
