### PR TITLE
v2.1.2-KG9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,14 +18,14 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.2-KG8
+version=2.1.2-KG9
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x
 group=io.vertx
 
 # dependency versions
-hazelcastVersion=3.5
+hazelcastVersion=3.5.5
 jacksonCoreVersion=2.2.2
 jacksonDatabindVersion=2.2.2
 nettyVersion=4.0.21.Final

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ title=vert.x
 group=io.vertx
 
 # dependency versions
-hazelcastVersion=3.2.3
+hazelcastVersion=3.5
 jacksonCoreVersion=2.2.2
 jacksonDatabindVersion=2.2.2
 nettyVersion=4.0.21.Final

--- a/vertx-core/src/main/java/org/vertx/java/core/http/RouteMatcher.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/RouteMatcher.java
@@ -18,7 +18,12 @@ package org.vertx.java.core.http;
 
 import org.vertx.java.core.Handler;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,15 +46,15 @@ import java.util.regex.Pattern;
  */
 public class RouteMatcher implements Handler<HttpServerRequest> {
 
-  private final List<PatternBinding> getBindings = new ArrayList<>();
-  private final List<PatternBinding> putBindings = new ArrayList<>();
-  private final List<PatternBinding> postBindings = new ArrayList<>();
-  private final List<PatternBinding> deleteBindings = new ArrayList<>();
-  private final List<PatternBinding> optionsBindings = new ArrayList<>();
-  private final List<PatternBinding> headBindings = new ArrayList<>();
-  private final List<PatternBinding> traceBindings = new ArrayList<>();
-  private final List<PatternBinding> connectBindings = new ArrayList<>();
-  private final List<PatternBinding> patchBindings = new ArrayList<>();
+  private final List<PatternBinding> getBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> putBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> postBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> deleteBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> optionsBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> headBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> traceBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> connectBindings = new CopyOnWriteArrayList<>();
+  private final List<PatternBinding> patchBindings = new CopyOnWriteArrayList<>();
   private Handler<HttpServerRequest> noMatchHandler;
 
   @Override

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServerFileUpload.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServerFileUpload.java
@@ -120,8 +120,20 @@ class DefaultHttpServerFileUpload implements HttpServerFileUpload {
         receiveData(pauseBuff);
         pauseBuff = null;
       }
-      if (complete && endHandler != null) {
-        endHandler.handle(null);
+      if (complete) {
+        if (file != null) {
+          file.close(new AsyncResultHandler<Void>() {
+            @Override
+            public void handle(AsyncResult<Void> event) {
+              if (event.failed()) {
+                notifyExceptionHandler(event.cause());
+              }
+              notifyEndHandler();
+            }
+          });
+        } else {
+          notifyEndHandler();
+        }
       }
     }
     return this;

--- a/vertx-core/src/main/java/org/vertx/java/core/impl/ConcurrentHashSet.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/ConcurrentHashSet.java
@@ -76,7 +76,7 @@ public class ConcurrentHashSet<E> implements Set<E> {
 
   @Override
   public boolean remove(Object o) {
-    return map.remove(o) == null;
+    return map.remove(o) != null;
   }
 
   @Override

--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/ChoosableSet.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/ChoosableSet.java
@@ -54,7 +54,9 @@ class ChoosableSet<T> implements ChoosableIterable<T> {
   }
 
   public void remove(T elem) {
-    ids.remove(elem);
+    if (ids.remove(elem)) {
+      iter = ids.iterator();
+    }
   }
 
   public void merge(ChoosableSet<T> toMerge) {

--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMap.java
@@ -17,6 +17,7 @@
 package org.vertx.java.spi.cluster.impl.hazelcast;
 
 import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.EntryListener;
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.AsyncResultHandler;
@@ -160,7 +161,15 @@ class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryListener
 
   @Override
   public void entryRemoved(EntryEvent<K, V> entry) {
-    removeEntry(entry.getKey(), entry.getValue());
+    removeEntry(entry.getKey(), entry.getOldValue());
+  }
+
+  public void mapCleared(MapEvent event) {
+    cache.clear();
+  }
+
+  public void mapEvicted(MapEvent event) {
+    cache.clear();
   }
 
   private void removeEntry(K k, V v) {

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/cli/Starter.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/cli/Starter.java
@@ -402,7 +402,9 @@ public class Starter {
           }
         });
         try {
-          if (!latch.await(30, TimeUnit.SECONDS)) {
+		  int undeployTimeout = Integer.getInteger("org.vertx.Starter.UNDEPLOY_TIMEOUT_SECONDS", 30);
+          log.info("Waiting for " + undeployTimeout + " seconds for undeployment...");
+          if (!latch.await(undeployTimeout, TimeUnit.SECONDS)) {
             log.error("Timed out waiting to undeploy");
           }
         } catch (InterruptedException e) {

--- a/vertx-testsuite/src/test/java/org/vertx/java/fakecluster/ChoosableSet.java
+++ b/vertx-testsuite/src/test/java/org/vertx/java/fakecluster/ChoosableSet.java
@@ -45,7 +45,9 @@ class ChoosableSet<T> implements ChoosableIterable<T> {
   }
 
   public void remove(T elem) {
-    ids.remove(elem);
+    if (ids.remove(elem)) {
+      iter = ids.iterator();
+	}
   }
 
   public void merge(ChoosableSet<T> toMerge) {


### PR DESCRIPTION
Main purpose of this pull request is to increase hazelcast dep to 3.5+. We decided to put in other useful fixes found on the vertx 2.x branch.

Additionally we fixed a bug in vertx' ConcurrentHashSet and ChoosableSet which may lead to usage of already removed serverIDs when sending messages.
