### PR TITLE
Fix for issue with out of order zip entries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.2-KG9
+version=2.1.2-KG10
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -1540,11 +1540,16 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
       while ((entry = zis.getNextEntry()) != null) {
         String entryName = zipinfo.oldStyle ? removeTopDir(entry.getName()) : entry.getName();
         if (!entryName.isEmpty()) {
+			File entryFile = new File(directory, entryName);
           if (entry.isDirectory()) {
-            if (!new File(directory, entryName).mkdir()) {
+			  if (!entryFile.exists() && !entryFile.mkdirs()) {
               throw new PlatformManagerException("Failed to create directory");
             }
           } else {
+			  File dir = entryFile.getParentFile();
+			  if (dir != null && !dir.exists() && !dir.mkdirs()) {
+				  throw new PlatformManagerException("Failed to create directory");
+			  }
             int count;
             byte[] buff = new byte[BUFFER_SIZE];
             BufferedOutputStream dest = null;

--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -1540,16 +1540,16 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
       while ((entry = zis.getNextEntry()) != null) {
         String entryName = zipinfo.oldStyle ? removeTopDir(entry.getName()) : entry.getName();
         if (!entryName.isEmpty()) {
-			File entryFile = new File(directory, entryName);
+          File entryFile = new File(directory, entryName);
           if (entry.isDirectory()) {
-			  if (!entryFile.exists() && !entryFile.mkdirs()) {
+            if (!entryFile.exists() && !entryFile.mkdirs()) {
               throw new PlatformManagerException("Failed to create directory");
             }
           } else {
-			  File dir = entryFile.getParentFile();
-			  if (dir != null && !dir.exists() && !dir.mkdirs()) {
-				  throw new PlatformManagerException("Failed to create directory");
-			  }
+            File dir = entryFile.getParentFile();
+            if (dir != null && !dir.exists() && !dir.mkdirs()) {
+              throw new PlatformManagerException("Failed to create directory");
+            }
             int count;
             byte[] buff = new byte[BUFFER_SIZE];
             BufferedOutputStream dest = null;


### PR DESCRIPTION
This is adapted from the commit in the link with the addition of the comment for the proper use of isDirectory()
https://github.com/eclipse/vert.x/commit/64ffa5a632995077f5ac5b3d6cbcb3aa75dee90f

It works locally and solves my problem of ZipEntries being out of order in a zip archive so that child files can be extracted before the single entry for the parent.
