### PR TITLE
Keep the AsyncMultiMap cache in sync even after split-brains 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.2-KG13
+version=2.1.2-KG14
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x

--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastClusterManager.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastClusterManager.java
@@ -37,7 +37,7 @@ import java.util.Set;
 
 /**
  * A cluster manager that uses Hazelcast
- * 
+ *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class HazelcastClusterManager implements ClusterManager, MembershipListener {
@@ -96,8 +96,8 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
 	 * @return subscription map
 	 */
   public <K, V> AsyncMultiMap<K, V> getAsyncMultiMap(final String name) {
-    com.hazelcast.core.MultiMap map = hazelcast.getMultiMap(name);
-    return new HazelcastAsyncMultiMap(vertx, map);
+    com.hazelcast.core.MultiMap<K,V> map = hazelcast.getMultiMap(name);
+    return new HazelcastAsyncMultiMap<>(vertx, hazelcast, map);
   }
 
   @Override

--- a/vertx-hazelcast/src/test/java/com/hazelcast/instance/HazelcastTestUtil.java
+++ b/vertx-hazelcast/src/test/java/com/hazelcast/instance/HazelcastTestUtil.java
@@ -1,0 +1,35 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+
+/**
+ * @author <a href="mailto:andreas.berger@kiwigrid.com">Andreas Berger</a>
+ */
+public class HazelcastTestUtil {
+  public static Node getNode(HazelcastInstance hz) {
+    HazelcastInstanceImpl impl = getHazelcastInstanceImpl(hz);
+    return impl != null ? impl.node : null;
+  }
+
+  public static HazelcastInstanceImpl getHazelcastInstanceImpl(HazelcastInstance hz) {
+    HazelcastInstanceImpl impl = null;
+    if (hz instanceof HazelcastInstanceProxy) {
+      impl = ((HazelcastInstanceProxy) hz).original;
+    } else if (hz instanceof HazelcastInstanceImpl) {
+      impl = (HazelcastInstanceImpl) hz;
+    }
+    return impl;
+  }
+
+  public static void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
+    if (h1 == null || h2 == null) {
+      return;
+    }
+    Node n1 = HazelcastTestUtil.getNode(h1);
+    Node n2 = HazelcastTestUtil.getNode(h2);
+    if (n1 != null && n2 != null) {
+      n1.clusterService.removeAddress(n2.address);
+      n2.clusterService.removeAddress(n1.address);
+    }
+  }
+}

--- a/vertx-platform/src/main/resources/default-cluster.xml
+++ b/vertx-platform/src/main/resources/default-cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.2.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <properties>
@@ -74,7 +74,7 @@
         <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
         <queue-capacity>0</queue-capacity>
     </executor-service>
-    <map name="subs">
+    <multimap name="subs">
 
         <!--
             Number of backups. If 1 is set as the backup-count for example,
@@ -82,59 +82,7 @@
             fail-safety. 0 means no backup.
         -->
         <backup-count>1</backup-count>
-        <!--
-			Maximum number of seconds for each entry to stay in the map. Entries that are
-			older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
-			will get automatically evicted from the map.
-			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
-		-->
-        <time-to-live-seconds>0</time-to-live-seconds>
-        <!--
-			Maximum number of seconds for each entry to stay idle in the map. Entries that are
-			idle(not touched) for more than <max-idle-seconds> will get
-			automatically evicted from the map. Entry is touched if get, put or containsKey is called.
-			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
-		-->
-        <max-idle-seconds>0</max-idle-seconds>
-        <!--
-            Valid values are:
-            NONE (no eviction),
-            LRU (Least Recently Used),
-            LFU (Least Frequently Used).
-            NONE is the default.
-        -->
-        <eviction-policy>NONE</eviction-policy>
-        <!--
-            Maximum size of the map. When max size is reached,
-            map is evicted based on the policy defined.
-            Any integer between 0 and Integer.MAX_VALUE. 0 means
-            Integer.MAX_VALUE. Default is 0.
-        -->
-        <max-size policy="PER_NODE">0</max-size>
-        <!--
-            When max. size is reached, specified percentage of
-            the map will be evicted. Any integer between 0 and 100.
-            If 25 is set for example, 25% of the entries will
-            get evicted.
-        -->
-        <eviction-percentage>25</eviction-percentage>
-        <!--
-            While recovering from split-brain (network partitioning),
-            map entries in the small cluster will merge into the bigger cluster
-            based on the policy set here. When an entry merge into the
-            cluster, there might an existing entry with the same key already.
-            Values of these entries might be different for that same key.
-            Which value should be set for the key? Conflict is resolved by
-            the policy set here. Default policy is PutIfAbsentMapMergePolicy
 
-            There are built-in merge policies such as
-            com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
-            com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
-            com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
-            com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
-        -->
-        <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
-
-    </map>
+    </multimap>
 
 </hazelcast>

--- a/vertx-testsuite/src/test/resources/cluster.xml
+++ b/vertx-testsuite/src/test/resources/cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.2.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <properties>
@@ -74,7 +74,7 @@
         <!--Queue capacity. 0 means Integer.MAX_VALUE.-->
         <queue-capacity>0</queue-capacity>
     </executor-service>
-    <map name="subs">
+    <multimap name="subs">
 
         <!--
             Number of backups. If 1 is set as the backup-count for example,
@@ -82,59 +82,6 @@
             fail-safety. 0 means no backup.
         -->
         <backup-count>1</backup-count>
-        <!--
-			Maximum number of seconds for each entry to stay in the map. Entries that are
-			older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
-			will get automatically evicted from the map.
-			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
-		-->
-        <time-to-live-seconds>0</time-to-live-seconds>
-        <!--
-			Maximum number of seconds for each entry to stay idle in the map. Entries that are
-			idle(not touched) for more than <max-idle-seconds> will get
-			automatically evicted from the map. Entry is touched if get, put or containsKey is called.
-			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
-		-->
-        <max-idle-seconds>0</max-idle-seconds>
-        <!--
-            Valid values are:
-            NONE (no eviction),
-            LRU (Least Recently Used),
-            LFU (Least Frequently Used).
-            NONE is the default.
-        -->
-        <eviction-policy>NONE</eviction-policy>
-        <!--
-            Maximum size of the map. When max size is reached,
-            map is evicted based on the policy defined.
-            Any integer between 0 and Integer.MAX_VALUE. 0 means
-            Integer.MAX_VALUE. Default is 0.
-        -->
-        <max-size policy="PER_NODE">0</max-size>
-        <!--
-            When max. size is reached, specified percentage of
-            the map will be evicted. Any integer between 0 and 100.
-            If 25 is set for example, 25% of the entries will
-            get evicted.
-        -->
-        <eviction-percentage>25</eviction-percentage>
-        <!--
-            While recovering from split-brain (network partitioning),
-            map entries in the small cluster will merge into the bigger cluster
-            based on the policy set here. When an entry merge into the
-            cluster, there might an existing entry with the same key already.
-            Values of these entries might be different for that same key.
-            Which value should be set for the key? Conflict is resolved by
-            the policy set here. Default policy is PutIfAbsentMapMergePolicy
-
-            There are built-in merge policies such as
-            com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
-            com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
-            com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
-            com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
-        -->
-        <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
-
-    </map>
+    </multimap>
 
 </hazelcast>


### PR DESCRIPTION
Keep the AsyncMultiMap cache in sync even after split-brains
**does not solve merge conflicts of MultiMap itself**
