### PR TITLE
Fix subs handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,14 +18,14 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.2-KG15
+version=2.1.2-KG16
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x
 group=io.vertx
 
 # dependency versions
-hazelcastVersion=3.5.5
+hazelcastVersion=3.7.2
 jacksonCoreVersion=2.2.2
 jacksonDatabindVersion=2.2.2
 nettyVersion=4.0.21.Final

--- a/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastClusterManager.java
+++ b/vertx-hazelcast/src/main/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastClusterManager.java
@@ -96,8 +96,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
 	 * @return subscription map
 	 */
   public <K, V> AsyncMultiMap<K, V> getAsyncMultiMap(final String name) {
-    com.hazelcast.core.MultiMap map = hazelcast.getMultiMap(name);
-    return new HazelcastAsyncMultiMap(vertx, map);
+    return new HazelcastAsyncMultiMap(vertx, hazelcast, name);
   }
 
   @Override

--- a/vertx-hazelcast/src/test/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMapTest.java
+++ b/vertx-hazelcast/src/test/java/org/vertx/java/spi/cluster/impl/hazelcast/HazelcastAsyncMultiMapTest.java
@@ -74,9 +74,9 @@ public class HazelcastAsyncMultiMapTest {
       }
     };
     IMap<String, Set<String>> hzMap1 = h1.getMap("foo");
-    HazelcastAsyncMultiMap<String, String> map1 = new HazelcastAsyncMultiMap<>(vertx, hzMap1);
+    HazelcastAsyncMultiMap<String, String> map1 = new HazelcastAsyncMultiMap<>(vertx, h1, "foo");
     IMap<String, Set<String>> hzMap2 = h2.getMap("foo");
-    HazelcastAsyncMultiMap<String, String> map2 = new HazelcastAsyncMultiMap<>(vertx, hzMap2);
+    HazelcastAsyncMultiMap<String, String> map2 = new HazelcastAsyncMultiMap<>(vertx, h2, "foo");
 
 
     addValue(map1, "key", "v0");


### PR DESCRIPTION
- use newest hazelcast b/c of bugs with member attribute propagation (https://github.com/hazelcast/hazelcast/issues/7697)
- clean up HazelcastAsyncMultiMap cache on splits and merges
